### PR TITLE
Spotlight accessibility staging kevins suggestions 1.

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,63 +19,55 @@
  */
 
 a {
-    color: #00648b;
-    text-decoration: none;
-    border-bottom: 1px dotted #00648b;
-  }
-
-
-a:hover {
-    color: #003f58;
-    text-decoration: none;
-    border-bottom: 1px solid #003f58;
-  }
-
-.exhibit-card .card-title .stretched-link {
-    outline: none;
-    border-bottom: none;
+  color: #00648b;
+  text-decoration: none;
+  border-bottom: 1px dotted #00648b;
 }
 
+a:hover {
+  color: #003f58;
+  text-decoration: none;
+  border-bottom: 1px solid #003f58;
+}
+
+.exhibit-card .card-title .stretched-link {
+  outline: none;
+  border-bottom: none;
+}
 
 .exhibit-card a {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .exhibit-card a:hover {
-    border-bottom: none;
+  border-bottom: none;
 }
-
 
 .site-footer .footer-lower a{
-   
-    border-bottom: none;
+  border-bottom: none;
 }
-
 
 .site-footer .footer-lower a:hover{
-    color:  #ffc222;
-    border-bottom: 1px dotted #ffc222;
+  color:  #ffc222;
+  border-bottom: 1px dotted #ffc222;
 }
-
 
 #published .nav-pills .nav-link {
-        border-bottom: none;
+  border-bottom: none;
 }
 
-
 .nav-item a, .nav-item a:hover {
-    border-bottom: none;
-
+  border-bottom: none;
 }
 
 .navbar-light .navbar-nav .nav-link {
-    color: #000000;
+  color: #000000;
 }
 
 .navbar-dark .navbar-nav .nav-link, .navbar-nav .nav-link {
-    color: #D1D1D1; 
+  color: #D1D1D1;
 }
 
 .image-masthead .exhibit-navbar {
-    background-color: #000000;
+  background-color: #000000;
 }

--- a/app/assets/stylesheets/spotlight.scss
+++ b/app/assets/stylesheets/spotlight.scss
@@ -15,58 +15,47 @@ body {
   font-family: "Lato", sans-serif;
 }
 
-
 a {
-    color: #00648b;
-    text-decoration: none;
-    border-bottom: 1px dotted #00648b;
-  }
-
-
-a:hover {
-    color: #003f58;
-    text-decoration: none;
-    border-bottom: 1px solid #003f58;
-  }
-
-.exhibit-card .card-title .stretched-link {
-    outline: none;
-    border-bottom: none;
+  color: #00648b;
+  text-decoration: none;
+  border-bottom: 1px dotted #00648b;
 }
 
+a:hover {
+  color: #003f58;
+  text-decoration: none;
+  border-bottom: 1px solid #003f58;
+}
+
+.exhibit-card .card-title .stretched-link {
+  outline: none;
+  border-bottom: none;
+}
 
 .exhibit-card a {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .exhibit-card a:hover {
-    border-bottom: none;
+  border-bottom: none;
 }
-
 
 .site-footer .footer-lower a{
-   
-    border-bottom: none;
+  border-bottom: none;
 }
-
 
 .site-footer .footer-lower a:hover{
-    color:  #ffc222;
-    border-bottom: 1px dotted #ffc222;
+  color:  #ffc222;
+  border-bottom: 1px dotted #ffc222;
 }
-
 
 #published .nav-pills .nav-link {
-        border-bottom: none;
+  border-bottom: none;
 }
-
 
 .nav-item a, .nav-item a:hover {
-    border-bottom: none;
-
+  border-bottom: none;
 }
-
-
 
 .bg-dark {
   background: $primary !important;

--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -1,9 +1,9 @@
 <% set_html_page_title @page.title if @page.should_display_title? %>
-<% render 'tophat' %>
+<%= render 'tophat' %>
 <%= render 'sidebar' if @page.display_sidebar? %>
 
-<%= cache_unless current_user, @page do %>
-<div class="<%= @page.display_sidebar? ? 'col-md-9' : 'col-md-12' %>">
+<% cache_unless current_user, @page do %>
+<div class="<%= @page.display_sidebar? ? 'col-md-9' : 'col-md-12' -%>">
   <div class="clearfix">
     <%= render 'edit_page_link' if can? :edit, @page %>
     <% if @page.should_display_title? %>


### PR DESCRIPTION
Change ERB printing behavior in spotlight show.html.erb.

The render top hat is likely not rendering because of `<%` rather than `<%=`.
Either the top hat SHOULD NOT BE shown or it SHOULD BE shown.
I am assuming that it SHOULD BE shown and so I am using `<%=`.

The `cache_unless` likely should not be printing.
Replace the `<%=` with `<%`.

The HTML tag class attribute has embedded ERB.
The embedded ERB prints a new line.
To avoid that, add a minus sign at the closing ERB tag.
That is to say use `-%>` instead of `%>`.

Clean up white space inconsistencies in recently modified CSS files.